### PR TITLE
Use `OpenAILike` for OpenAI LLMs

### DIFF
--- a/fuzzing_llm_engine/models/get_model.py
+++ b/fuzzing_llm_engine/models/get_model.py
@@ -1,5 +1,4 @@
 from llama_index.llms.openai_like import OpenAILike
-from models.openai import OpenAI
 from llama_index.llms.ollama import Ollama
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.embeddings.ollama import OllamaEmbedding
@@ -17,7 +16,7 @@ def get_model(llm_config=None):
         return OpenAILike(model=model_name, api_base=llm_config["base_url"], api_key=llm_config["api_key"], is_chat_model=True, temperature=llm_config["temperature"] )
     if model_name.startswith("openai"):
         model_name = model_name.replace("openai-", "").strip()
-        return OpenAI(model=model_name, api_key=llm_config.api_key)    
+        return OpenAILike(model=model_name, api_base=llm_config["base_url"], api_key=llm_config["api_key"], is_chat_model=True, temperature=llm_config["temperature"])
     if model_name.startswith("ollama"):
         model_name = model_name.replace("ollama-", "").strip()
         return Ollama(model=model_name,  base_url=llm_config["base_url"], request_timeout=llm_config["request_timeout"]) # http://csl-server14.dynip.ntu.edu.sg:51030"


### PR DESCRIPTION
Currently CKGFuzzer does not work for OpenAI LLMs.
```
Traceback (most recent call last):
  File "/CKGFuzzer/fuzzing_llm_engine/fuzzing.py", line 130, in <module>
    llm_coder = get_model(config["llm_coder"] if "llm_coder" in config else config["llm_analyzer"])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/CKGFuzzer/fuzzing_llm_engine/models/get_model.py", line 20, in get_model
    return OpenAI(model=model_name, api_key=llm_config.api_key)
                                            ^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'api_key'
```

It seems `OpenAIModel` is used for it. However, if we use this class here, it will trigger error:
```
Traceback (most recent call last):
  File "/CKGFuzzer/fuzzing_llm_engine/fuzzing.py", line 143, in <module>
    Settings.llm = llm_analyzer
    ^^^^^^^^^^^^
  File "/opt/conda/envs/ckg/lib/python3.11/site-packages/llama_index/core/settings.py", line 46, in llm
    self._llm = resolve_llm(llm)
                ^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/ckg/lib/python3.11/site-packages/llama_index/core/llms/utils.py", line 102, in resolve_llm
    assert isinstance(llm, LLM)
           ^^^^^^^^^^^^^^^^^^^^
AssertionError
```

So I just use `OpenAILike` here.